### PR TITLE
KH-252_upload

### DIFF
--- a/koodisto-service/src/main/java/fi/vm/sade/koodisto/service/business/impl/UploadBusinessServiceImpl.java
+++ b/koodisto-service/src/main/java/fi/vm/sade/koodisto/service/business/impl/UploadBusinessServiceImpl.java
@@ -86,11 +86,7 @@ public class UploadBusinessServiceImpl implements UploadBusinessService {
                 updateDatas.add(updateData);
             }
             return koodiBusinessService.massCreate(koodistoUri, updateDatas);
-        } catch (IOException e) {
-            throw new KoodistoImportException(e);
-        } catch (InvalidKoodiCsvLineException e) {
-            throw new KoodistoImportException(e);
-        } catch (UnmarshallingFailureException e) {
+        } catch (IOException | InvalidKoodiCsvLineException | UnmarshallingFailureException e) {
             throw new KoodistoImportException(e);
         }
     }

--- a/koodisto-service/src/main/java/fi/vm/sade/koodisto/service/koodisto/rest/CodesResource.java
+++ b/koodisto-service/src/main/java/fi/vm/sade/koodisto/service/koodisto/rest/CodesResource.java
@@ -383,9 +383,9 @@ public class CodesResource {
             notes = "",
             response = Response.class)
     public Response uploadFile(
-            @ApiParam(value = "Tuotava tiedosto") @Multipart("uploadedFile") Attachment fileInputStream,
-            @ApiParam(value = "Tiedostotyyppi") @Multipart("fileFormat") String fileFormat,
-            @ApiParam(value = "Tiedoston koodaus") @Multipart("fileEncoding") String fileEncoding,
+            @ApiParam(value = "Tuotava tiedosto") @Multipart(value = "uploadedFile", required = false) Attachment fileInputStream,
+            @ApiParam(value = "Tiedostotyyppi") @Multipart(value = "fileFormat", required = false) String fileFormat,
+            @ApiParam(value = "Tiedoston koodaus") @Multipart(value = "fileEncoding", required = false) String fileEncoding,
             @ApiParam(value = "Koodiston URI") @PathParam("codesUri") String codesUri) {
         try {
             String[] errors = { "file", "fileformat", "codesuri" };

--- a/koodisto-service/src/main/java/fi/vm/sade/koodisto/service/koodisto/rest/CodesResource.java
+++ b/koodisto-service/src/main/java/fi/vm/sade/koodisto/service/koodisto/rest/CodesResource.java
@@ -383,9 +383,9 @@ public class CodesResource {
             notes = "",
             response = Response.class)
     public Response uploadFile(
-            @ApiParam(value = "Tiedoston koodaus") @Multipart("fileEncoding") String fileEncoding,
-            @ApiParam(value = "Tiedostotyyppi") @Multipart("fileFormat") String fileFormat,
             @ApiParam(value = "Tuotava tiedosto") @Multipart("uploadedFile") Attachment fileInputStream,
+            @ApiParam(value = "Tiedostotyyppi") @Multipart("fileFormat") String fileFormat,
+            @ApiParam(value = "Tiedoston koodaus") @Multipart("fileEncoding") String fileEncoding,
             @ApiParam(value = "Koodiston URI") @PathParam("codesUri") String codesUri) {
         try {
             String[] errors = { "file", "fileformat", "codesuri" };

--- a/koodisto-service/src/main/java/fi/vm/sade/koodisto/service/koodisto/rest/CodesResource.java
+++ b/koodisto-service/src/main/java/fi/vm/sade/koodisto/service/koodisto/rest/CodesResource.java
@@ -1,53 +1,10 @@
 package fi.vm.sade.koodisto.service.koodisto.rest;
 
-import java.io.File;
-import java.io.InputStream;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.ResponseBuilder;
-
-import org.apache.commons.lang.StringUtils;
-import org.apache.cxf.jaxrs.ext.multipart.InputStreamDataSource;
 import com.fasterxml.jackson.annotation.JsonView;
-import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
-
-import com.sun.jersey.multipart.FormDataParam;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-
 import fi.vm.sade.generic.service.conversion.SadeConversionService;
 import fi.vm.sade.generic.service.exception.SadeBusinessException;
-import fi.vm.sade.koodisto.dto.KoodistoChangesDto;
-import fi.vm.sade.koodisto.dto.KoodistoDto;
-import fi.vm.sade.koodisto.dto.KoodistoListDto;
-import fi.vm.sade.koodisto.dto.KoodistoRyhmaListDto;
-import fi.vm.sade.koodisto.dto.KoodistoVersioListDto;
-import fi.vm.sade.koodisto.model.Format;
-import fi.vm.sade.koodisto.model.JsonViews;
-import fi.vm.sade.koodisto.model.Koodisto;
-import fi.vm.sade.koodisto.model.KoodistoVersio;
-import fi.vm.sade.koodisto.model.SuhteenTyyppi;
+import fi.vm.sade.koodisto.dto.*;
+import fi.vm.sade.koodisto.model.*;
 import fi.vm.sade.koodisto.service.DownloadService;
 import fi.vm.sade.koodisto.service.business.KoodistoBusinessService;
 import fi.vm.sade.koodisto.service.business.UploadBusinessService;
@@ -60,7 +17,31 @@ import fi.vm.sade.koodisto.service.koodisto.rest.validator.ValidatorUtil;
 import fi.vm.sade.koodisto.service.types.SearchKoodistosCriteriaType;
 import fi.vm.sade.koodisto.service.types.common.ExportImportFormatType;
 import fi.vm.sade.koodisto.util.KoodistoServiceSearchCriteriaBuilder;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.apache.commons.lang.StringUtils;
+import org.apache.cxf.jaxrs.ext.multipart.Attachment;
+import org.apache.cxf.jaxrs.ext.multipart.InputStreamDataSource;
+import org.apache.cxf.jaxrs.ext.multipart.Multipart;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+
+import javax.activation.DataHandler;
+import javax.activation.DataSource;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @Controller
 @Path("/codes")
@@ -402,9 +383,9 @@ public class CodesResource {
             notes = "",
             response = Response.class)
     public Response uploadFile(
-            @ApiParam(value = "Tuotava tiedosto") @FormDataParam("uploadedFile") InputStream fileInputStream,
-            @ApiParam(value = "Tiedostotyyppi") @FormDataParam("fileFormat") String fileFormat,
-            @ApiParam(value = "Tiedoston koodaus") @FormDataParam("fileEncoding") String fileEncoding,
+            @ApiParam(value = "Tiedoston koodaus") @Multipart("fileEncoding") String fileEncoding,
+            @ApiParam(value = "Tiedostotyyppi") @Multipart("fileFormat") String fileFormat,
+            @ApiParam(value = "Tuotava tiedosto") @Multipart("uploadedFile") Attachment fileInputStream,
             @ApiParam(value = "Koodiston URI") @PathParam("codesUri") String codesUri) {
         try {
             String[] errors = { "file", "fileformat", "codesuri" };
@@ -437,7 +418,7 @@ public class CodesResource {
                 break;
             }
 
-            DataSource ds = new InputStreamDataSource(fileInputStream, mime);
+            DataSource ds = new InputStreamDataSource(fileInputStream.getDataHandler().getInputStream(), mime);
             DataHandler handler = new DataHandler(ds);
             KoodistoVersio kv = uploadService.upload(codesUri, formatStr, encoding, handler);
             return Response.status(Response.Status.ACCEPTED).entity(kv.getVersio().toString()).build();


### PR DESCRIPTION
Käytetään CXF:n annotaatioita multipart rajapinnassa. Jersey tuuppasi koko viestin sisällön ensimmäiseen stringiin eikä tälle löytynyt erityistä syytä.