### PR TITLE
BUG-2162: also publish parent artifact on deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
 
 deploy:
   - provider: script
-    script: mvn deploy -pl koodisto-api -am -DskipTests --settings ci-tools/common/maven-settings.xml
+    script: mvn deploy -pl fi.vm.sade.koodisto:koodisto,koodisto-api -am -DskipTests --settings ci-tools/common/maven-settings.xml
     skip_cleanup: true
     on:
       branch: master


### PR DESCRIPTION
Samaan tyyliin kuin esim. haku-appissa, eli varsinainen api paketti ei julkaistu SNAPSHOTtina välttämättä oikein jos samalla ei ensin julkaista parenttia.