### PR TITLE
Set application timezone to UTC during startup

### DIFF
--- a/koodisto-service/src/main/java/fi/vm/sade/koodisto/KoodistoApplication.java
+++ b/koodisto-service/src/main/java/fi/vm/sade/koodisto/KoodistoApplication.java
@@ -3,11 +3,13 @@ package fi.vm.sade.koodisto;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class KoodistoApplication {
 
 	public static void main(String[] args) {
+		TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 		SpringApplication.run(KoodistoApplication.class, args);
 	}
-
 }


### PR DESCRIPTION
* workaround for very strange jackson serialization issue. some
  dates were adjusted by timezone offset while some were not which
  cased inconsistency between endpoint responses.